### PR TITLE
Add skipping to hello_world

### DIFF
--- a/exercises/hello-world/hello_world.pl
+++ b/exercises/hello-world/hello_world.pl
@@ -1,0 +1,9 @@
+% Please visit http://exercism.io/languages/prolog/installing
+% for instructions on setting up prolog.
+% Visit http://exercism.io/languages/prolog/tests
+% for help running the tests for prolog exercises.
+
+% Replace the goal below with
+% your implementation.
+
+hello_world(false).

--- a/exercises/hello-world/hello_world_tests.plt
+++ b/exercises/hello-world/hello_world_tests.plt
@@ -1,11 +1,28 @@
+% Please visit http://exercism.io/languages/prolog/installing
+% for instructions on setting up prolog.
+% Visit http://exercism.io/languages/prolog/tests
+% for help running the tests for prolog exercises.
+
+% The goal below allows tests to be skipped
+% unless the "--all" flag is passed at
+% the command line.
+
+pending :-
+    current_prolog_flag(argv, ['--all'|_]).
+
 :- begin_tests(hello_word).
+
     test(hello_world) :-
         hello_world('Hello World!').
 
-    test(hello_world_fail, blocked("Pending")) :-
+    % Once the first test passes, un-skip the following test by
+    % changing `pending` in `condition(pedning)` to `true`.
+    % Repeat for each test until they are all passing.
+
+    test(hello_world_with_a_name , condition(pending)) :-
         hello_world('Alice', 'Hello Alice!').
 
-    test(hello_world_fail, blocked("Pending")) :-
+    test(hello_world_another_name, condition(pending)) :-
         hello_world('Bob', 'Hello Bob!').
 
 :- end_tests(hello_word).


### PR DESCRIPTION
I'd like to propose the changes in the PR as a way to skip tests until the user is ready to run them. Instead of `blocked`, which will not allow tests to run on CI, I propose using `condition(pending)`. This means adding a `pending` goal to the top of each test file like this:

```
pending :-
    current_prolog_flag(argv, ['--all'|_]).
```

We can then pass `--all` as a command line argument when running tests in CI or when running the track's build locally, and all tests will be executed. 

The only issue I am struggling with is that plunit does not report skipped tests when using `condition/1`. The output for the user looks like this:

```
% PL-Unit: hello_word
ERROR: /Users/parker/code/xprolog/exercises/hello-world/hello_world_tests.plt:15:
	test hello_world: failed

 done
% 1 test failed
% 0 tests passed
```

I'm going to make a second PR showing how we could make the output more verbose, but I think this code is cleaner and adds less noise to the test file. 

@kytrinyx I'd love your take on this if you have a quick sec to look it over.