### PR TITLE
Add more verbose test skipping

### DIFF
--- a/exercises/hello-world/hello_world.pl
+++ b/exercises/hello-world/hello_world.pl
@@ -1,0 +1,9 @@
+% Please visit http://exercism.io/languages/prolog/installing
+% for instructions on setting up prolog.
+% Visit http://exercism.io/languages/prolog/tests
+% for help running the tests for prolog exercises.
+
+% Replace the goal below with
+% your implementation.
+
+hello_world(false).

--- a/exercises/hello-world/hello_world_tests.plt
+++ b/exercises/hello-world/hello_world_tests.plt
@@ -1,11 +1,31 @@
+% Please visit http://exercism.io/languages/prolog/installing
+% for instructions on setting up prolog.
+% Visit http://exercism.io/languages/prolog/tests
+% for help running the tests for prolog exercises.
+
+% The goal below allows tests to be skipped
+% unless the "--all" flag is passed at
+% the command line.
+
+pending :-
+    current_prolog_flag(argv, ['--all'|_]).
+pending :-
+    write('\nA TEST IS PENDING!\n'),
+    fail.
+
 :- begin_tests(hello_word).
+
     test(hello_world) :-
         hello_world('Hello World!').
 
-    test(hello_world_fail, blocked("Pending")) :-
+    % Once the first test passes, un-skip the following test by
+    % changing `pending` in `condition(pedning)` to `true`.
+    % Repeat for each test until they are all passing.
+
+    test(hello_world_with_a_name, condition(pending)) :-
         hello_world('Alice', 'Hello Alice!').
 
-    test(hello_world_fail, blocked("Pending")) :-
+    test(hello_world_another_name, condition(pending)) :-
         hello_world('Bob', 'Hello Bob!').
 
 :- end_tests(hello_word).


### PR DESCRIPTION
As promised, here is an implementation of test skipping that reports which tests were skipped. I think this adds too much noise to the test file, but maybe it is worth it to give the user more information. Each test would have to carefully be created with its own `condition(pending(hello_world_with_a_name))` and the name is duplicated in each test goal. Here is the output:

```
ERROR: /Users/parker/code/xprolog/exercises/hello-world/hello_world_tests.plt:19:
    test hello_world: failed


skipping hello_world_with_a_name
skipping hello_world_another_name done
% 1 test failed
% 0 tests passed
```

and when the test passes:

```
% PL-Unit: hello_word .
skipping hello_world_with_a_name
skipping hello_world_another_name done
% test passed
```
