### PR TITLE
Make sure at least one test fails for each exercise

### DIFF
--- a/exercises/anagram/anagram_tests.plt
+++ b/exercises/anagram/anagram_tests.plt
@@ -1,7 +1,8 @@
 :- begin_tests(anagram).
 
     test(no_matches) :-
-        anagram("diaper", [ "hello", "world", "zombies", "pants"], []).
+        anagram("diaper", [ "hello", "world", "zombies", "pants"], Result),
+        is_list(Result).
 
     test(detects_simple_anagram) :-
         anagram("ant", ["tan", "stand", "at"], ["tan"]).

--- a/exercises/sum-of-multiples/sum_of_multiples_tests.plt
+++ b/exercises/sum-of-multiples/sum_of_multiples_tests.plt
@@ -1,7 +1,8 @@
 :- begin_tests(sum_of_multiples).
 
     test(low_limit) :-
-        sum_of_multiples([3, 5], 1, 0).
+        sum_of_multiples([3, 5], 1, Result),
+        Result == 0.
 
     test(just_one_multiple) :-
         sum_of_multiples([3, 5], 4, 3).


### PR DESCRIPTION
In anagram and sum_of_multiples running the example file against the tests allowed all tests to pass. That is because prolog could unify the empty variables against all the inputs.