### PR TITLE
Capitalise the language name to look a little better

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "slug": "prolog",
-  "language": "prolog",
+  "language": "Prolog",
   "repository": "https://github.com/exercism/xprolog",
   "active": false,
   "exercises": [


### PR DESCRIPTION
Prolog is the only non-capitalised one and it should be capitalised.

![standout](https://cloud.githubusercontent.com/assets/3238748/23575638/136035ce-005e-11e7-86ab-d47d1db77562.png)
